### PR TITLE
Fix Docker build to use release mode instead of debug

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -72,6 +72,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
+          build-args: |
+            RUST_RELEASE_MODE=release
 
   build-lemmy-ui:
     name: Build Lemmy UI


### PR DESCRIPTION
## Summary
Fixes the Docker build workflow to compile Lemmy in **release mode** instead of debug mode, which was causing performance issues and federation timeouts.

## Problem
The Docker workflow was missing the `RUST_RELEASE_MODE=release` build argument, causing images to be built in debug mode by default. Debug builds are:
- **Significantly slower** (no compiler optimizations, 10-100x slower)
- **Much larger** in size (includes debug symbols)
- **Unable to handle federation load** properly

This was causing `InboxTimeout` errors because the debug build couldn't process incoming ActivityPub activities within the 9-second timeout window.

## Solution
Added the missing `build-args` configuration to the Docker build step:
```yaml
build-args: |
  RUST_RELEASE_MODE=release
```

This aligns our build process with the official dessalines/lemmy images from upstream.

## Testing
After merging and deploying:
1. Rebuild Docker images (they will now be optimized release builds)
2. Deploy the new images
3. Monitor logs - `InboxTimeout` errors should be drastically reduced or eliminated

## Changes
- Modified `.github/workflows/docker-build.yml` to add `RUST_RELEASE_MODE=release` build argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)