### PR TITLE
Merge upstream 0.19.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "forked-main", "v0.19.13-theatl", "20251003/add-login-hook", "20251202/beta-refactor" ]
+    branches: [ "forked-main", "v0.19.13-theatl", "20251003/add-login-hook", "20251202/beta-refactor", "merge/*" ]
   pull_request:
-    branches: [ "forked-main", "v0.19.13-theatl", "20251202/beta-refactor" ]
+    branches: [ "forked-main", "v0.19.13-theatl", "20251202/beta-refactor", "merge/*" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,10 +2,10 @@ name: Build Docker Images
 
 on:
   push:
-    branches: [ "forked-main", "v0.19.13-theatl", "20251202/beta-refactor" ]
+    branches: [ "forked-main", "v0.19.13-theatl", "20251202/beta-refactor", "merge/*" ]
     tags: [ "v*" ]
   pull_request:
-    branches: [ "forked-main", "v0.19.13-theatl", "20251202/beta-refactor" ]
+    branches: [ "forked-main", "v0.19.13-theatl", "20251202/beta-refactor", "merge/*" ]
   workflow_dispatch:
     inputs:
       branch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3452,6 +3452,7 @@ dependencies = [
  "reqwest-middleware 0.2.5",
  "rss",
  "serde",
+ "strum",
  "tokio",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.15"
+version = "0.19.16-beta.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.16-beta.1"
+version = "0.19.16"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "8f27d075294830fcab6f66e320dab524bc6d048f4a151698e153205559113772"
 
 [[package]]
 name = "activitypub_federation"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03b8d2bd50274f13eb426dba2a54b83df3ae462472b351022f05f57319a269d"
+checksum = "3f270340d07aba4f16feb008cd63af31595d6782961a12ab1ae8dc3fd6514189"
 dependencies = [
  "activitystreams-kinds",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.16"
+version = "0.19.17-beta.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.17-beta.0"
+version = "0.19.17"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.15"
+version = "0.19.16-beta.0"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.15", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.15", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.15", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.15", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.15", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.15", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.15", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.15", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.15", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.15", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.15", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.16-beta.0", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.16-beta.0", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.16-beta.0", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.16-beta.0", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.16-beta.0", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.16-beta.0", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.16-beta.0", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.16-beta.0", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.16-beta.0", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.16-beta.0", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.16-beta.0", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.10", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.16-beta.0"
+version = "0.19.16-beta.1"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.16-beta.0", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.16-beta.0", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.16-beta.0", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.16-beta.0", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.16-beta.0", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.16-beta.0", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.16-beta.0", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.16-beta.0", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.16-beta.0", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.16-beta.0", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.16-beta.0", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.16-beta.1", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.16-beta.1", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.16-beta.1", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.16-beta.1", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.16-beta.1", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.16-beta.1", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.16-beta.1", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.16-beta.1", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.16-beta.1", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.16-beta.1", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.16-beta.1", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.10", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.16"
+version = "0.19.17-beta.0"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.16", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.16", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.16", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.16", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.16", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.16", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.16", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.16", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.16", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.16", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.16", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.17-beta.0", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.17-beta.0", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.17-beta.0", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.17-beta.0", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.17-beta.0", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.17-beta.0", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.17-beta.0", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.17-beta.0", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.17-beta.0", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.17-beta.0", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.17-beta.0", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.17-beta.0"
+version = "0.19.17"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.17-beta.0", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.17-beta.0", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.17-beta.0", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.17-beta.0", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.17-beta.0", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.17-beta.0", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.17-beta.0", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.17-beta.0", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.17-beta.0", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.17-beta.0", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.17-beta.0", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.17", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.17", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.17", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.17", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.17", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.17", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.17", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.17", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.17", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.17", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.17", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.16-beta.1"
+version = "0.19.16"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.16-beta.1", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.16-beta.1", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.16-beta.1", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.16-beta.1", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.16-beta.1", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.16-beta.1", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.16-beta.1", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.16-beta.1", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.16-beta.1", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.16-beta.1", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.16-beta.1", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.16", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.16", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.16", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.16", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.16", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.16", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.16", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.16", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.16", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.16", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.16", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.10", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ lemmy_db_views = { version = "=0.19.16", path = "./crates/db_views" }
 lemmy_db_views_actor = { version = "=0.19.16", path = "./crates/db_views_actor" }
 lemmy_db_views_moderator = { version = "=0.19.16", path = "./crates/db_views_moderator" }
 lemmy_federate = { version = "=0.19.16", path = "./crates/federate" }
-activitypub_federation = { version = "0.5.10", default-features = false, features = [
+activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }
 diesel = "2.2.3"

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -34,7 +34,7 @@ use reqwest::{
 };
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use tokio::net::lookup_host;
 use tracing::{info, warn};
 use url::Url;
@@ -70,19 +70,13 @@ pub async fn fetch_link_metadata(
     // TODO: Replace with IpAddr::is_global() once stabilized
     //       https://doc.rust-lang.org/std/net/enum.IpAddr.html#method.is_global
     let domain = url.domain().ok_or(LemmyErrorType::UrlWithoutDomain)?;
-    let invalid_ip = lookup_host((domain.to_owned(), 80))
-      .await?
-      .any(|addr| match addr.ip() {
-        IpAddr::V4(addr) => {
-          addr.is_private() || addr.is_link_local() || addr.is_loopback() || addr.is_multicast()
-        }
-        IpAddr::V6(addr) => {
-          addr.is_loopback()
-                        || addr.is_multicast()
-                        || ((addr.segments()[0] & 0xfe00) == 0xfc00) // is_unique_local
-                        || ((addr.segments()[0] & 0xffc0) == 0xfe80) // is_unicast_link_local
-        }
-      });
+    let invalid_ip =
+      lookup_host((domain.to_owned(), 80))
+        .await?
+        .any(|addr| match addr.ip().to_canonical() {
+          IpAddr::V4(addr) => v4_is_invalid(addr),
+          IpAddr::V6(addr) => v6_is_invalid(addr),
+        });
     if invalid_ip {
       return Err(LemmyErrorType::InvalidUrl.into());
     }
@@ -165,6 +159,30 @@ pub async fn fetch_link_metadata(
     opengraph_data,
     content_type: content_type.map(|c| c.to_string()),
   })
+}
+
+fn v4_is_invalid(v4: Ipv4Addr) -> bool {
+  v4.is_private()
+    || v4.is_loopback()
+    || v4.is_link_local()
+    || v4.is_multicast()
+    || v4.is_documentation()
+    || v4.is_unspecified()
+    || v4.is_broadcast()
+}
+
+fn v6_is_invalid(v6: Ipv6Addr) -> bool {
+  let is_documentation = matches!(
+    v6.segments(),
+    [0x2001, 0xdb8, ..] | [0x3fff, 0..=0x0fff, ..]
+  );
+  is_documentation
+    || v6.is_loopback()
+    || v6.is_multicast()
+        || (v6.segments()[0] & 0xfe00) == 0xfc00 // is_unique_local
+        || (v6.segments()[0] & 0xffc0) == 0xfe80 // is_unicast_link_local
+    || v6.is_unspecified()
+    || v6.to_ipv4_mapped().is_some_and(v4_is_invalid)
 }
 
 async fn collect_bytes_until_limit(

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -430,8 +430,12 @@ pub async fn build_db_pool() -> LemmyResult<ActualDbPool> {
   let mut config = ManagerConfig::default();
   config.custom_setup = Box::new(establish_connection);
   let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_config(&db_url, config);
+
+  // Don't allow pool sizes below 2. See https://github.com/LemmyNet/lemmy/issues/5112
+  let pool_size = std::cmp::max(SETTINGS.database.pool_size, 2);
+
   let pool = Pool::builder(manager)
-    .max_size(SETTINGS.database.pool_size)
+    .max_size(pool_size)
     .runtime(Runtime::Tokio1)
     // Limit connection age to prevent use of prepared statements that have query plans based on
     // very old statistics

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::{newtypes::DbUrl, CommentSortType, SortType};
 use chrono::{DateTime, TimeDelta, Utc};
-use deadpool::Runtime;
+use deadpool::{managed::Timeouts, Runtime};
 use diesel::{
   helper_types::AsExprOf,
   pg::Pg,
@@ -437,6 +437,11 @@ pub async fn build_db_pool() -> LemmyResult<ActualDbPool> {
   let pool = Pool::builder(manager)
     .max_size(pool_size)
     .runtime(Runtime::Tokio1)
+    .timeouts(Timeouts {
+      wait: Some(Duration::from_secs(1)),
+      create: Some(Duration::from_secs(5)),
+      recycle: Some(Duration::from_secs(5)),
+    })
     // Limit connection age to prevent use of prepared statements that have query plans based on
     // very old statistics
     .pre_recycle(Hook::sync_fn(|_conn, metrics| {

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -33,5 +33,6 @@ serde = { workspace = true }
 url = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+strum = { workspace = true }
 http.workspace = true
 rss = "2.0.10"

--- a/crates/routes/src/images.rs
+++ b/crates/routes/src/images.rs
@@ -24,7 +24,7 @@ use lemmy_utils::{
 };
 use reqwest::Body;
 use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::{str::FromStr, time::Duration};
 use strum::{Display, EnumString};
 use url::Url;
@@ -61,7 +61,7 @@ impl ProcessUrl for PictrsGetParams {
       format!("{}image/original/{}", pictrs_url, src)
     } else {
       // Take file type from name, or jpg if nothing is given
-      let format = file_type(self.format.clone(), src).unwrap_or(PictrsFileType::Jpg);
+      let format = file_type(self.format.clone(), src).unwrap_or_default();
 
       let mut url = format!("{}image/process.{}?src={}", pictrs_url, format, src);
 
@@ -73,13 +73,13 @@ impl ProcessUrl for PictrsGetParams {
   }
 }
 
-#[derive(EnumString, Display, Debug, Serialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-#[strum(ascii_case_insensitive)]
+#[derive(EnumString, Display, PartialEq, Debug, Default)]
+#[strum(ascii_case_insensitive, serialize_all = "snake_case")]
 enum PictrsFileType {
   Apng,
   Avif,
   Gif,
+  #[default]
   Jpg,
   Jxl,
   Png,
@@ -108,7 +108,7 @@ impl ProcessUrl for ImageProxyParams {
       format!("{}image/original?proxy={}", pictrs_url, proxy_url)
     } else {
       // Take file type from name, or jpg if nothing is given
-      let format = file_type(self.format.clone(), proxy_url).unwrap_or(PictrsFileType::Jpg);
+      let format = file_type(self.format.clone(), proxy_url).unwrap_or_default();
 
       let mut url = format!("{}image/process.{}?proxy={}", pictrs_url, format, proxy_url);
 
@@ -343,5 +343,53 @@ where
     cx: &mut std::task::Context<'_>,
   ) -> std::task::Poll<Option<Self::Item>> {
     std::pin::Pin::new(&mut self.rx).poll_recv(cx)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::images::{file_type, PictrsFileType};
+  use lemmy_utils::error::LemmyResult;
+
+  #[tokio::test]
+  async fn image_file_type_tests() -> LemmyResult<()> {
+    // Make sure files type outputs are getting lower-cased
+    assert_eq!(PictrsFileType::Jpg.to_string(), "jpg".to_string());
+
+    let file_url = "a8a7f07f-3ef2-40fa-849c-ae952f68f3ec.jpg";
+
+    // Make sure wrong-cased file type requests are okay
+    assert_eq!(
+      PictrsFileType::Jpg,
+      file_type(Some("JPg".to_string()), file_url)?
+    );
+
+    // Make sure wrong file type requests are okay with unwrap_or_default
+    assert_eq!(
+      PictrsFileType::Jpg,
+      file_type(Some("jpeg".to_string()), file_url).unwrap_or_default()
+    );
+    assert_eq!(
+      PictrsFileType::Jpg,
+      file_type(Some("nonsense".to_string()), file_url).unwrap_or_default()
+    );
+
+    // Make sure missing file type requests are okay
+    assert_eq!(PictrsFileType::Jpg, file_type(None, file_url)?);
+
+    // jpeg
+    let file_url = "a8a7f07f-3ef2-40fa-849c-ae952f68f3ec.jpeg";
+
+    // Make sure jpeg one is okay
+    assert_eq!(
+      PictrsFileType::Jpg,
+      file_type(None, file_url).unwrap_or_default()
+    );
+
+    // Make sure proxy ones are okay
+    let proxy_url = "https://test.tld/pictrs/image/6d3b2f3f-7b29-4d9a-868e-b269423f4d6c.WEbP";
+    assert_eq!(PictrsFileType::Webp, file_type(None, proxy_url)?);
+
+    Ok(())
   }
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   lemmy:
     # use "image" to pull down an already compiled lemmy. make sure to comment out "build".
-    # image: dessalines/lemmy:0.19.15
+    # image: dessalines/lemmy:0.19.16
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy server image for development. make sure to comment out "image".
     # run: docker compose up --build
@@ -53,7 +53,7 @@ services:
 
   lemmy-ui:
     # use "image" to pull down an already compiled lemmy-ui. make sure to comment out "build".
-    image: dessalines/lemmy-ui:0.19.15
+    image: dessalines/lemmy-ui:0.19.16
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy ui image for development. make sure to comment out "image".
     # run: docker compose up --build

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   lemmy:
     # use "image" to pull down an already compiled lemmy. make sure to comment out "build".
-    # image: dessalines/lemmy:0.19.16
+    # image: dessalines/lemmy:0.19.17
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy server image for development. make sure to comment out "image".
     # run: docker compose up --build
@@ -53,7 +53,7 @@ services:
 
   lemmy-ui:
     # use "image" to pull down an already compiled lemmy-ui. make sure to comment out "build".
-    image: dessalines/lemmy-ui:0.19.16
+    image: dessalines/lemmy-ui:0.19.17
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy ui image for development. make sure to comment out "image".
     # run: docker compose up --build

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 x-ui-default: &ui-default
   init: true
-  image: dessalines/lemmy-ui:0.19.16
+  image: dessalines/lemmy-ui:0.19.17
   # assuming lemmy-ui is cloned besides lemmy directory
   # build:
   #   context: ../../../lemmy-ui

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 x-ui-default: &ui-default
   init: true
-  image: dessalines/lemmy-ui:0.19.15
+  image: dessalines/lemmy-ui:0.19.16
   # assuming lemmy-ui is cloned besides lemmy directory
   # build:
   #   context: ../../../lemmy-ui


### PR DESCRIPTION
## Summary
- Merges upstream Lemmy release **0.19.17** into the theatl-social fork
- Key upstream change: **Improved IP checks** ([LemmyNet/lemmy#6411](https://github.com/LemmyNet/lemmy/pull/6411)) — touches request handling, DB utils, and image routing
- Dependency updates and version bumps (0.19.15 → 0.19.16 → 0.19.17)
- Merge was conflict-free; all fork customizations verified intact

## Fork customizations verified
- [x] Private API (`privileged_register`, `check_email` endpoints)
- [x] `private_api_secret` settings config
- [x] Fork CI/CD workflow branch triggers
- [x] `generate_translations.js`
- [x] `subtle` crate dependency for constant-time comparison

## Files changed (upstream)
- `Cargo.lock` / `Cargo.toml` — dependency updates
- `crates/api_common/src/request.rs` — IP check improvements
- `crates/db_schema/src/utils.rs` — DB utility updates
- `crates/routes/Cargo.toml` + `src/images.rs` — image proxy refactoring
- `docker/docker-compose.yml` / `docker/federation/docker-compose.yml` — Docker config updates

## Test plan
- [x] `cargo build` passes
- [ ] `cargo test` on CI
- [ ] Deploy to staging and verify private API endpoints still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)