### PR TITLE
Merge upstream Lemmy 0.19.18

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -239,7 +239,7 @@ steps:
       - "# If you can't see all output, then use the download button"
     when:
       - event: pull_request
-        status: failure
+        status: [failure]
 
   publish_release_docker:
     image: woodpeckerci/plugin-docker-buildx
@@ -295,7 +295,7 @@ steps:
       - "curl -d'Lemmy CI build failed: ${CI_PIPELINE_URL}' ntfy.sh/lemmy_drone_ci"
     when:
       - event: [pull_request, tag]
-        status: failure
+        status: [failure]
 
   notify_on_tag_deploy:
     image: alpine:3
@@ -312,3 +312,6 @@ services:
     environment:
       POSTGRES_USER: lemmy
       POSTGRES_PASSWORD: password
+    # Woodpecker's services ending is now causing pipeline failures:
+    # https://github.com/woodpecker-ci/woodpecker/issues/6372
+    failure: ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.18-beta.3"
+version = "0.19.18"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.17"
+version = "0.19.18-beta.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.18-beta.1"
+version = "0.19.18-beta.3"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.18-beta.1", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.18-beta.1", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.18-beta.1", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.18-beta.1", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.18-beta.1", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.18-beta.1", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.18-beta.1", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.18-beta.1", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.18-beta.1", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.18-beta.1", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.18-beta.1", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.18-beta.3", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.18-beta.3", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.18-beta.3", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.18-beta.3", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.18-beta.3", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.18-beta.3", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.18-beta.3", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.18-beta.3", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.18-beta.3", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.18-beta.3", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.18-beta.3", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.18-beta.0"
+version = "0.19.18-beta.1"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.18-beta.0", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.18-beta.0", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.18-beta.0", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.18-beta.0", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.18-beta.0", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.18-beta.0", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.18-beta.0", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.18-beta.0", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.18-beta.0", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.18-beta.0", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.18-beta.0", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.18-beta.1", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.18-beta.1", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.18-beta.1", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.18-beta.1", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.18-beta.1", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.18-beta.1", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.18-beta.1", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.18-beta.1", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.18-beta.1", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.18-beta.1", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.18-beta.1", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.18-beta.3"
+version = "0.19.18"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.18-beta.3", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.18-beta.3", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.18-beta.3", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.18-beta.3", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.18-beta.3", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.18-beta.3", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.18-beta.3", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.18-beta.3", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.18-beta.3", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.18-beta.3", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.18-beta.3", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.18", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.18", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.18", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.18", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.18", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.18", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.18", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.18", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.18", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.18", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.18", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.17"
+version = "0.19.18-beta.0"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.17", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.17", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.17", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.17", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.17", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.17", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.17", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.17", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.17", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.17", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.17", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.18-beta.0", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.18-beta.0", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.18-beta.0", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.18-beta.0", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.18-beta.0", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.18-beta.0", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.18-beta.0", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.18-beta.0", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.18-beta.0", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.18-beta.0", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.18-beta.0", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use tokio::net::lookup_host;
 use tracing::{info, warn};
-use url::Url;
+use url::{Host, Url};
 use urlencoding::encode;
 use webpage::HTML;
 
@@ -64,24 +64,7 @@ pub async fn fetch_link_metadata(
     return Err(LemmyErrorType::InvalidUrl.into());
   }
 
-  // Resolve the domain and throw an error if it points to any internal IP,
-  // using logic from nightly IpAddr::is_global.
-  if !cfg!(debug_assertions) {
-    // TODO: Replace with IpAddr::is_global() once stabilized
-    //       https://doc.rust-lang.org/std/net/enum.IpAddr.html#method.is_global
-    let domain = url.domain().ok_or(LemmyErrorType::UrlWithoutDomain)?;
-    let invalid_ip =
-      lookup_host((domain.to_owned(), 80))
-        .await?
-        .any(|addr| match addr.ip().to_canonical() {
-          IpAddr::V4(addr) => v4_is_invalid(addr),
-          IpAddr::V6(addr) => v6_is_invalid(addr),
-        });
-    if invalid_ip {
-      return Err(LemmyErrorType::InvalidUrl.into());
-    }
-  }
-
+  validate_link_ip(url).await?;
   info!("Fetching site metadata for url: {}", url);
   // We only fetch the first MB of data in order to not waste bandwidth especially for large
   // binary files. This high limit is particularly needed for youtube, which includes a lot of
@@ -159,6 +142,37 @@ pub async fn fetch_link_metadata(
     opengraph_data,
     content_type: content_type.map(|c| c.to_string()),
   })
+}
+
+/// Resolve the domain and throw an error if it points to any internal IP.
+pub async fn validate_link_ip(url: &Url) -> LemmyResult<()> {
+  if cfg!(debug_assertions) {
+    return Ok(());
+  }
+  // Resolve the domain and throw an error if it points to any internal IP,
+  // using logic from nightly IpAddr::is_global.
+
+  // TODO: Replace with IpAddr::is_global() once stabilized
+  //       https://doc.rust-lang.org/std/net/enum.IpAddr.html#method.is_global
+  let mut ip = vec![];
+  match url.host().ok_or(LemmyErrorType::UrlWithoutDomain)? {
+    Host::Domain(domain) => ip.extend(
+      lookup_host((domain.to_owned(), 80))
+        .await?
+        .map(|s| s.ip().to_canonical()),
+    ),
+    Host::Ipv4(ipv4) => ip.push(ipv4.into()),
+    Host::Ipv6(ipv6) => ip.push(ipv6.into()),
+  };
+
+  let invalid_ip = ip.into_iter().any(|addr| match addr {
+    IpAddr::V4(addr) => v4_is_invalid(addr),
+    IpAddr::V6(addr) => v6_is_invalid(addr),
+  });
+  if invalid_ip {
+    return Err(LemmyErrorType::InvalidUrl.into());
+  }
+  Ok(())
 }
 
 fn v4_is_invalid(v4: Ipv4Addr) -> bool {

--- a/crates/api_common/src/request.rs
+++ b/crates/api_common/src/request.rs
@@ -404,6 +404,7 @@ struct PictrsPurgeResponse {
 /// - It might not be an image
 /// - Pictrs might not be set up
 pub async fn purge_image_from_pictrs(image_url: &Url, context: &LemmyContext) -> LemmyResult<()> {
+  validate_link_ip(image_url).await?;
   is_image_content_type(context.client(), image_url).await?;
 
   let alias = image_url
@@ -457,6 +458,7 @@ pub async fn delete_image_from_pictrs(
 /// Retrieves the image with local pict-rs and generates a thumbnail. Returns the thumbnail url.
 #[tracing::instrument(skip_all)]
 async fn generate_pictrs_thumbnail(image_url: &Url, context: &LemmyContext) -> LemmyResult<Url> {
+  validate_link_ip(image_url).await?;
   let pictrs_config = context.settings().pictrs_config()?;
 
   match pictrs_config.image_mode() {
@@ -516,6 +518,7 @@ pub async fn fetch_pictrs_proxied_image_details(
   image_url: &Url,
   context: &LemmyContext,
 ) -> LemmyResult<PictrsFileDetails> {
+  validate_link_ip(image_url).await?;
   let pictrs_url = context.settings().pictrs_config()?.url;
   let encoded_image_url = encode(image_url.as_str());
 

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::{
   context::LemmyContext,
-  request::{delete_image_from_pictrs, fetch_pictrs_proxied_image_details},
+  request::{delete_image_from_pictrs, fetch_pictrs_proxied_image_details, validate_link_ip},
   site::{FederatedInstances, InstanceWithFederationState},
 };
 use chrono::{DateTime, Days, Local, TimeZone, Utc};
@@ -913,6 +913,7 @@ async fn proxy_image_link_internal(
   image_mode: PictrsImageMode,
   context: &LemmyContext,
 ) -> LemmyResult<DbUrl> {
+  validate_link_ip(&link).await?;
   // Dont rewrite links pointing to local domain.
   if link.domain() == Some(&context.settings().hostname) {
     Ok(link.into())

--- a/crates/api_crud/src/post/create.rs
+++ b/crates/api_crud/src/post/create.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   build_response::build_post_response,
   context::LemmyContext,
   post::{CreatePost, PostResponse},
-  request::generate_post_link_metadata,
+  request::{generate_post_link_metadata, validate_link_ip},
   send_activity::SendActivityData,
   utils::{
     check_community_user_action,
@@ -178,7 +178,7 @@ pub async fn create_post(
   mark_post_as_read(person_id, post_id, &mut context.pool()).await?;
 
   if let Some(url) = inserted_post.url.clone() {
-    if community.visibility == CommunityVisibility::Public {
+    if community.visibility == CommunityVisibility::Public && validate_link_ip(&url).await.is_ok() {
       spawn_try_task(async move {
         let mut webmention =
           Webmention::new::<Url>(inserted_post.ap_id.clone().into(), url.clone().into())?;

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -18,13 +18,7 @@ use activitypub_federation::{
 use chrono::{DateTime, Utc};
 use lemmy_api_common::{
   context::LemmyContext,
-  utils::{
-    check_comment_depth,
-    get_url_blocklist,
-    is_mod_or_admin,
-    local_site_opt_to_slur_regex,
-    process_markdown,
-  },
+  utils::{get_url_blocklist, is_mod_or_admin, local_site_opt_to_slur_regex, process_markdown},
 };
 use lemmy_db_schema::{
   source::{
@@ -42,7 +36,6 @@ use lemmy_utils::{
   utils::markdown::markdown_to_html,
 };
 use std::ops::Deref;
-use tokio::spawn;
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -171,16 +164,7 @@ impl Object for ApubComment {
     ))
     .await?;
 
-    // When fetching a deeply nested comment we may have also have to fetch dozens of parent
-    // comments which can easily result in stack overflow. So we launch a new task instead
-    // which gives a new stack and avoids overflow. This was successfully tested with a comment
-    // nested 200 deep (max in production is 50).
-    let note2 = note.clone();
-    let context2 = context.reset_request_count();
-    let (post, parent_comment) = spawn(async move { note2.get_parents(&context2).await }).await??;
-    if let Some(c) = &parent_comment {
-      check_comment_depth(c)?;
-    }
+    let (post, _) = note.get_parents(context).await?;
 
     let creator = Box::pin(note.attributed_to.dereference(context)).await?;
     let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), &creator, community.id)

--- a/crates/apub/src/objects/comment.rs
+++ b/crates/apub/src/objects/comment.rs
@@ -42,6 +42,7 @@ use lemmy_utils::{
   utils::markdown::markdown_to_html,
 };
 use std::ops::Deref;
+use tokio::spawn;
 use url::Url;
 
 #[derive(Clone, Debug)]
@@ -170,7 +171,17 @@ impl Object for ApubComment {
     ))
     .await?;
 
-    let (post, _) = Box::pin(note.get_parents(context)).await?;
+    // When fetching a deeply nested comment we may have also have to fetch dozens of parent
+    // comments which can easily result in stack overflow. So we launch a new task instead
+    // which gives a new stack and avoids overflow. This was successfully tested with a comment
+    // nested 200 deep (max in production is 50).
+    let note2 = note.clone();
+    let context2 = context.reset_request_count();
+    let (post, parent_comment) = spawn(async move { note2.get_parents(&context2).await }).await??;
+    if let Some(c) = &parent_comment {
+      check_comment_depth(c)?;
+    }
+
     let creator = Box::pin(note.attributed_to.dereference(context)).await?;
     let is_mod_or_admin = is_mod_or_admin(&mut context.pool(), &creator, community.id)
       .await
@@ -188,10 +199,8 @@ impl Object for ApubComment {
   #[tracing::instrument(skip_all)]
   async fn from_json(note: Note, context: &Data<LemmyContext>) -> LemmyResult<ApubComment> {
     let creator = note.attributed_to.dereference(context).await?;
+    // Parent comment is already fetched in verify method, no risk of stack overflow here.
     let (post, parent_comment) = note.get_parents(context).await?;
-    if let Some(c) = &parent_comment {
-      check_comment_depth(c)?;
-    }
 
     let content = read_from_string_or_source(&note.content, &note.media_type, &note.source);
 

--- a/crates/apub/src/protocol/objects/note.rs
+++ b/crates/apub/src/protocol/objects/note.rs
@@ -19,14 +19,15 @@ use activitypub_federation::{
   },
 };
 use chrono::{DateTime, Utc};
-use lemmy_api_common::context::LemmyContext;
+use lemmy_api_common::{context::LemmyContext, utils::check_comment_depth};
 use lemmy_db_schema::{
   source::{community::Community, post::Post},
   traits::Crud,
 };
-use lemmy_utils::{error::LemmyResult, LemmyErrorType, MAX_COMMENT_DEPTH_LIMIT};
+use lemmy_utils::{error::LemmyResult, LemmyErrorType};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+use tokio::spawn;
 use url::Url;
 
 #[skip_serializing_none]
@@ -63,21 +64,18 @@ impl Note {
     &self,
     context: &Data<LemmyContext>,
   ) -> LemmyResult<(ApubPost, Option<ApubComment>)> {
-    // We use recursion here to fetch the entire comment chain up to the top-level parent. This is
-    // necessary because we need to know the post and parent comment in order to insert a new
-    // comment. However it can also lead to stack overflow when fetching many comments recursively.
-    // To avoid this we check the request count against max comment depth, which based on testing
-    // can be handled without risking stack overflow. This is not a perfect solution, because in
-    // some cases we have to fetch user profiles too, and reach the limit after only 25 comments
-    // or so.
-    // A cleaner solution would be converting the recursion into a loop, but that is tricky.
-    if context.request_count() > MAX_COMMENT_DEPTH_LIMIT as u32 {
-      Err(LemmyErrorType::MaxCommentDepthReached)?;
-    }
-    let parent = self.in_reply_to.dereference(context).await?;
+    // When fetching a deeply nested comment we may have also have to fetch dozens of parent
+    // comments which can easily result in stack overflow. So we launch a new task instead
+    // which gives a new stack and avoids overflow. This was successfully tested with a comment
+    // nested 200 deep (max in production is 50).
+    let self2 = self.clone();
+    let context2 = context.reset_request_count();
+    let parent = spawn(async move { self2.in_reply_to.dereference(&context2).await }).await??;
+
     match parent {
       PostOrComment::Post(p) => Ok((p.clone(), None)),
       PostOrComment::Comment(c) => {
+        check_comment_depth(&c)?;
         let post_id = c.post_id;
         let post = Post::read(&mut context.pool(), post_id)
           .await?

--- a/crates/db_schema/src/utils.rs
+++ b/crates/db_schema/src/utils.rs
@@ -438,9 +438,9 @@ pub async fn build_db_pool() -> LemmyResult<ActualDbPool> {
     .max_size(pool_size)
     .runtime(Runtime::Tokio1)
     .timeouts(Timeouts {
-      wait: Some(Duration::from_secs(1)),
-      create: Some(Duration::from_secs(5)),
-      recycle: Some(Duration::from_secs(5)),
+      wait: Some(Duration::from_secs(30)),
+      create: Some(Duration::from_secs(60)),
+      recycle: Some(Duration::from_secs(60)),
     })
     // Limit connection age to prevent use of prepared statements that have query plans based on
     // very old statistics

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   lemmy:
     # use "image" to pull down an already compiled lemmy. make sure to comment out "build".
-    # image: dessalines/lemmy:0.19.17
+    # image: dessalines/lemmy:0.19.18
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy server image for development. make sure to comment out "image".
     # run: docker compose up --build
@@ -53,7 +53,7 @@ services:
 
   lemmy-ui:
     # use "image" to pull down an already compiled lemmy-ui. make sure to comment out "build".
-    image: dessalines/lemmy-ui:0.19.17
+    image: dessalines/lemmy-ui:0.19.18
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy ui image for development. make sure to comment out "image".
     # run: docker compose up --build

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 x-ui-default: &ui-default
   init: true
-  image: dessalines/lemmy-ui:0.19.17
+  image: dessalines/lemmy-ui:0.19.18
   # assuming lemmy-ui is cloned besides lemmy directory
   # build:
   #   context: ../../../lemmy-ui


### PR DESCRIPTION
## Summary

Merges upstream Lemmy stable release `0.19.18` into `forked-main`. Small patch release — 11 files, ~92/-80 lines — that is overwhelmingly *defensive* in nature.

### Upstream changes
- **`Add more checks for internal IPs` (#6454)** — extracts `validate_link_ip` as a reusable function and applies it to 5 additional code paths that previously had **no SSRF filter**: `purge_image_from_pictrs`, `generate_pictrs_thumbnail`, `fetch_pictrs_proxied_image_details`, `proxy_image_link_internal`, and webmention emission in `create_post`. Also handles literal-IP URLs (`Host::Ipv4`/`Host::Ipv6`) which the previous `url.domain()`-based check did not cover cleanly.
- **`Add IP check for webmention` (#6444)** — gates webmention sending on the new IP filter via `validate_link_ip(&url).await.is_ok()` (silently skips webmention for invalid URLs rather than failing post creation).
- **`Launch new task to avoid stack overflow during nested comment fetch` (#6424) + `Proper fix for nested comment fetch (fixes #6435)` (#6451)** — replaces the `Box::pin` recursion + request-count depth limiter with `tokio::spawn` + `context.reset_request_count()`. Each level of `in_reply_to` chain runs on a fresh stack, and `check_comment_depth` is invoked inside the `PostOrComment::Comment` arm of `get_parents` rather than once at the top of `from_json`.
- **`Increase timeouts for db pool` (#6441)** — bumps pool wait/create/recycle from 1s/5s/5s to 30s/60s/60s.

## Security review

A focused security review of the delta found **no high-confidence security vulnerabilities newly introduced** by this merge. The changes are overwhelmingly security improvements:

- Old code calling `url.domain()` returned `None` for literal-IP URLs; the new code uses `url.host()` with exhaustive `Host::Domain`/`Host::Ipv4`/`Host::Ipv6` matching. `to_canonical()` is preserved, so IPv4-mapped IPv6 (e.g. `::ffff:127.0.0.1`) is still correctly normalized and rejected.
- The `validate_link_ip` filter is now applied to image-proxy and pictrs paths that previously took caller-controlled URLs with no SSRF check.
- The local-hostname short-circuit in `proxy_image_link_internal` sits **after** the IP check, so it cannot be used to bypass the filter.
- The TOCTOU between `lookup_host` and the subsequent `client().get(url)` resolve is unchanged from prior versions — pre-existing structural limitation, not introduced by this merge.
- The nested-comment-fetch fix removes the cross-task federation request counter (`context.reset_request_count()` on each recursion). This is a theoretical fediverse-DoS-amplification concern but not an auth-bypass, RCE, or data-exposure issue.

## Fork-specific notes

- Clean `ort` merge from upstream tag `0.19.18` on top of `merge/0.19.17` — no conflicts, meaning the fork's customizations (`privileged_register`, `check_email_registered`, custom IP overrides, private-API endpoints) do not overlap with any file touched by 0.19.18.
- Subsequent merge of `origin/forked-main` into this branch picks up the recent `build-lemmy-ui` CI job (`2d739531d`) + submodules fix (`6711450db`) so this PR does not inadvertently revert them.

## Test plan

- [ ] CI passes on `merge/0.19.18`
- [ ] Smoke-test on staging (yall.theatl.social)
- [ ] Confirm fork-specific custom routes (`privileged_register`, `check_email_registered`) still respond as expected
- [ ] Confirm `validate_link_ip` does not break legitimate image/webmention paths in production
- [ ] Confirm federation inbox still accepts nested comments under typical depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)