### PR TITLE
Merge upstream 0.19.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.19-beta.1"
+version = "0.19.19"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.18"
+version = "0.19.19-beta.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.19-beta.0"
+version = "0.19.19-beta.1"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.19-beta.0", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.19-beta.0", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.19-beta.0", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.19-beta.0", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.19-beta.0", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.19-beta.0", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.19-beta.0", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.19-beta.0", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.19-beta.0", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.19-beta.0", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.19-beta.0", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.19-beta.1", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.19-beta.1", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.19-beta.1", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.19-beta.1", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.19-beta.1", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.19-beta.1", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.19-beta.1", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.19-beta.1", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.19-beta.1", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.19-beta.1", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.19-beta.1", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.19-beta.1"
+version = "0.19.19"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.19-beta.1", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.19-beta.1", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.19-beta.1", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.19-beta.1", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.19-beta.1", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.19-beta.1", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.19-beta.1", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.19-beta.1", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.19-beta.1", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.19-beta.1", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.19-beta.1", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.19", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.19", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.19", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.19", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.19", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.19", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.19", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.19", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.19", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.19", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.19", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.18"
+version = "0.19.19-beta.0"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.18", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.18", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.18", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.18", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.18", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.18", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.18", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.18", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.18", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.18", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.18", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.19-beta.0", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.19-beta.0", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.19-beta.0", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.19-beta.0", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.19-beta.0", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.19-beta.0", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.19-beta.0", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.19-beta.0", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.19-beta.0", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.19-beta.0", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.19-beta.0", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 url = { workspace = true }
+tokio = { workspace = true }
 hound = "3.5.1"
 sitemap-rs = "0.2.1"
 totp-rs = { version = "5.7.0", features = ["gen_secret", "otpauth"] }

--- a/crates/api/src/comment/distinguish.rs
+++ b/crates/api/src/comment/distinguish.rs
@@ -41,7 +41,7 @@ pub async fn distinguish_comment(
 
   // Verify that only a mod or admin can distinguish a comment
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     orig_comment.community.id,
     false,
     &mut context.pool(),

--- a/crates/api/src/comment_report/resolve.rs
+++ b/crates/api/src/comment_report/resolve.rs
@@ -23,7 +23,7 @@ pub async fn resolve_comment_report(
 
   let person_id = local_user_view.person.id;
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     report.community.id,
     true,
     &mut context.pool(),

--- a/crates/api/src/community/add_mod.rs
+++ b/crates/api/src/community/add_mod.rs
@@ -27,13 +27,7 @@ pub async fn add_mod_to_community(
   let community_id = data.community_id;
 
   // Verify that only mods or admins can add mod
-  check_community_mod_action(
-    &local_user_view.person,
-    community_id,
-    false,
-    &mut context.pool(),
-  )
-  .await?;
+  check_community_mod_action(&local_user_view, community_id, false, &mut context.pool()).await?;
 
   // If its a mod removal, also check that you're a higher mod.
   if !data.added {

--- a/crates/api/src/community/ban.rs
+++ b/crates/api/src/community/ban.rs
@@ -38,7 +38,7 @@ pub async fn ban_from_community(
 
   // Verify that only mods or admins can ban
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     data.community_id,
     false,
     &mut context.pool(),

--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -17,6 +17,7 @@ use lemmy_db_schema::{
 };
 use lemmy_db_views::structs::{LocalUserView, SiteView};
 use lemmy_utils::error::{LemmyErrorType, LemmyResult};
+use tokio::task::spawn_blocking;
 
 #[tracing::instrument(skip(context))]
 pub async fn login(
@@ -27,27 +28,31 @@ pub async fn login(
   let site_view = SiteView::read_local(&mut context.pool())
     .await?
     .ok_or(LemmyErrorType::LocalSiteNotSetup)?;
+  let password = data.password.clone();
 
   // Fetch that username / email
   let username_or_email = data.username_or_email.clone();
   let local_user_view =
-    LocalUserView::find_by_email_or_name(&mut context.pool(), &username_or_email)
-      .await?
-      .ok_or({
-        // Dummy bcrypt verify for constant timing
-        let _ = verify(
-          &data.password,
-          "$2b$12$000000000000000000000000000000000000000000",
-        );
-        LemmyErrorType::IncorrectLogin
-      })?;
+    match LocalUserView::find_by_email_or_name(&mut context.pool(), &username_or_email).await {
+      Ok(Some(o)) => o,
+      _e => {
+        spawn_blocking(move || {
+          // Dummy bcrypt verify for constant timing
+          let _ = verify(
+            &data.password,
+            "$2b$12$dt1Xr.ZGO8W1YtWoJRtpauM1.bkBt2C1Tck3XgZTSoBQRdGuYCTTy",
+          );
+        })
+        .await?;
+        return Err(LemmyErrorType::IncorrectLogin.into());
+      }
+    };
 
   // Verify the password
-  let valid: bool = verify(
-    &data.password,
-    &local_user_view.local_user.password_encrypted,
-  )
-  .unwrap_or(false);
+  let password_encrypted = local_user_view.local_user.password_encrypted.clone();
+  let valid: bool = spawn_blocking(move || verify(&password, &password_encrypted))
+    .await?
+    .unwrap_or(false);
   if !valid {
     Err(LemmyErrorType::IncorrectLogin)?
   }

--- a/crates/api/src/local_user/login.rs
+++ b/crates/api/src/local_user/login.rs
@@ -33,7 +33,14 @@ pub async fn login(
   let local_user_view =
     LocalUserView::find_by_email_or_name(&mut context.pool(), &username_or_email)
       .await?
-      .ok_or(LemmyErrorType::IncorrectLogin)?;
+      .ok_or({
+        // Dummy bcrypt verify for constant timing
+        let _ = verify(
+          &data.password,
+          "$2b$12$000000000000000000000000000000000000000000",
+        );
+        LemmyErrorType::IncorrectLogin
+      })?;
 
   // Verify the password
   let valid: bool = verify(

--- a/crates/api/src/post/feature.rs
+++ b/crates/api/src/post/feature.rs
@@ -30,7 +30,7 @@ pub async fn feature_post(
     .ok_or(LemmyErrorType::CouldntFindPost)?;
 
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     orig_post.community_id,
     false,
     &mut context.pool(),

--- a/crates/api/src/post/lock.rs
+++ b/crates/api/src/post/lock.rs
@@ -29,7 +29,7 @@ pub async fn lock_post(
     .ok_or(LemmyErrorType::CouldntFindPost)?;
 
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     orig_post.community_id,
     false,
     &mut context.pool(),

--- a/crates/api/src/post_report/resolve.rs
+++ b/crates/api/src/post_report/resolve.rs
@@ -23,7 +23,7 @@ pub async fn resolve_post_report(
 
   let person_id = local_user_view.person.id;
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     report.community.id,
     true,
     &mut context.pool(),

--- a/crates/api_common/src/utils.rs
+++ b/crates/api_common/src/utils.rs
@@ -237,13 +237,15 @@ async fn check_community_ban(
 /// In particular it checks that he is an admin or mod, wasn't banned and the community isn't
 /// removed/deleted.
 pub async fn check_community_mod_action(
-  person: &Person,
+  local_user_view: &LocalUserView,
   community_id: CommunityId,
   allow_deleted: bool,
   pool: &mut DbPool<'_>,
 ) -> LemmyResult<()> {
-  is_mod_or_admin(pool, person, community_id).await?;
-  check_community_ban(person, community_id, pool).await?;
+  is_mod_or_admin(pool, &local_user_view.person, community_id).await?;
+  if !local_user_view.local_user.admin {
+    check_community_ban(&local_user_view.person, community_id, pool).await?;
+  }
 
   // it must be possible to restore deleted community
   if !allow_deleted {

--- a/crates/api_crud/src/comment/remove.rs
+++ b/crates/api_crud/src/comment/remove.rs
@@ -35,7 +35,7 @@ pub async fn remove_comment(
   .ok_or(LemmyErrorType::CouldntFindComment)?;
 
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     orig_comment.community.id,
     false,
     &mut context.pool(),

--- a/crates/api_crud/src/community/delete.rs
+++ b/crates/api_crud/src/community/delete.rs
@@ -26,13 +26,7 @@ pub async fn delete_community(
   let community_mods =
     CommunityModeratorView::for_community(&mut context.pool(), community_id).await?;
 
-  check_community_mod_action(
-    &local_user_view.person,
-    community_id,
-    true,
-    &mut context.pool(),
-  )
-  .await?;
+  check_community_mod_action(&local_user_view, community_id, true, &mut context.pool()).await?;
 
   // Make sure deleter is the top mod
   is_top_mod(&local_user_view, &community_mods)?;

--- a/crates/api_crud/src/community/remove.rs
+++ b/crates/api_crud/src/community/remove.rs
@@ -24,7 +24,7 @@ pub async fn remove_community(
   local_user_view: LocalUserView,
 ) -> LemmyResult<Json<CommunityResponse>> {
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     data.community_id,
     true,
     &mut context.pool(),

--- a/crates/api_crud/src/community/update.rs
+++ b/crates/api_crud/src/community/update.rs
@@ -37,7 +37,7 @@ pub async fn update_community(
 ) -> LemmyResult<Json<CommunityResponse>> {
   // Verify its a mod (only mods can edit it)
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     data.community_id,
     false,
     &mut context.pool(),

--- a/crates/api_crud/src/post/remove.rs
+++ b/crates/api_crud/src/post/remove.rs
@@ -31,7 +31,7 @@ pub async fn remove_post(
     .ok_or(LemmyErrorType::CouldntFindPost)?;
 
   check_community_mod_action(
-    &local_user_view.person,
+    &local_user_view,
     orig_post.community_id,
     false,
     &mut context.pool(),

--- a/crates/api_crud/src/private_message/update.rs
+++ b/crates/api_crud/src/private_message/update.rs
@@ -4,7 +4,7 @@ use lemmy_api_common::{
   context::LemmyContext,
   private_message::{EditPrivateMessage, PrivateMessageResponse},
   send_activity::{ActivityChannel, SendActivityData},
-  utils::{get_url_blocklist, local_site_to_slur_regex, process_markdown},
+  utils::{check_person_block, get_url_blocklist, local_site_to_slur_regex, process_markdown},
 };
 use lemmy_db_schema::{
   source::{
@@ -42,6 +42,13 @@ pub async fn update_private_message(
   let url_blocklist = get_url_blocklist(&context).await?;
   let content = process_markdown(&data.content, &slur_regex, &url_blocklist, &context).await?;
   is_valid_body_field(&content, false)?;
+
+  check_person_block(
+    local_user_view.person.id,
+    orig_private_message.recipient_id,
+    &mut context.pool(),
+  )
+  .await?;
 
   let private_message_id = data.private_message_id;
   PrivateMessage::update(

--- a/crates/apub/src/activities/community/collection_add.rs
+++ b/crates/apub/src/activities/community/collection_add.rs
@@ -30,7 +30,7 @@ use lemmy_db_schema::{
   source::{
     activity::ActivitySendTargets,
     community::{Community, CommunityModerator, CommunityModeratorForm},
-    moderator::{ModAddCommunity, ModAddCommunityForm},
+    moderator::{ModAddCommunity, ModAddCommunityForm, ModFeaturePost, ModFeaturePostForm},
     person::Person,
     post::{Post, PostUpdateForm},
   },
@@ -132,6 +132,8 @@ impl ActivityHandler for CollectionAdd {
       Community::get_by_collection_url(&mut context.pool(), &self.target.into())
         .await?
         .ok_or(LemmyErrorType::CouldntFindCommunity)?;
+    let actor = self.actor.dereference(context).await?;
+
     match collection_type {
       CollectionType::Moderators => {
         let new_mod = ObjectId::<ApubPerson>::from(self.object)
@@ -152,7 +154,6 @@ impl ActivityHandler for CollectionAdd {
           CommunityModerator::join(&mut context.pool(), &form).await?;
 
           // write mod log
-          let actor = self.actor.dereference(context).await?;
           let form = ModAddCommunityForm {
             mod_person_id: actor.id,
             other_person_id: new_mod.id,
@@ -167,11 +168,21 @@ impl ActivityHandler for CollectionAdd {
         let post = ObjectId::<ApubPost>::from(self.object)
           .dereference(context)
           .await?;
+        if post.community_id != community.id {
+          return Err(LemmyErrorType::InvalidCommunity.into());
+        }
         let form = PostUpdateForm {
           featured_community: Some(true),
           ..Default::default()
         };
         Post::update(&mut context.pool(), post.id, &form).await?;
+        let form = ModFeaturePostForm {
+          mod_person_id: actor.id,
+          post_id: post.id,
+          featured: true,
+          is_featured_community: true,
+        };
+        ModFeaturePost::create(&mut context.pool(), &form).await?;
       }
     }
     Ok(())

--- a/crates/apub/src/activities/community/collection_remove.rs
+++ b/crates/apub/src/activities/community/collection_remove.rs
@@ -26,6 +26,7 @@ use lemmy_db_schema::{
   source::{
     activity::ActivitySendTargets,
     community::{Community, CommunityModerator, CommunityModeratorForm},
+    local_user::LocalUser,
     moderator::{ModAddCommunity, ModAddCommunityForm},
     post::{Post, PostUpdateForm},
   },
@@ -129,9 +130,23 @@ impl ActivityHandler for CollectionRemove {
         .ok_or(LemmyErrorType::CouldntFindCommunity)?;
     match collection_type {
       CollectionType::Moderators => {
+        let actor = self.actor.dereference(context).await?;
         let remove_mod = ObjectId::<ApubPerson>::from(self.object)
           .dereference(context)
           .await?;
+
+        // If it's a local community, check if the actor is a higher mod than the removed mod.
+        // For remote communities we trust that the mod info is correct (because we may not have
+        // complete info to validate it).
+        if community.local {
+          LocalUser::is_higher_mod_or_admin_check(
+            &mut context.pool(),
+            community.id,
+            actor.id,
+            vec![remove_mod.id],
+          )
+          .await?;
+        }
 
         let form = CommunityModeratorForm {
           community_id: community.id,

--- a/crates/apub/src/activities/community/collection_remove.rs
+++ b/crates/apub/src/activities/community/collection_remove.rs
@@ -27,7 +27,7 @@ use lemmy_db_schema::{
     activity::ActivitySendTargets,
     community::{Community, CommunityModerator, CommunityModeratorForm},
     local_user::LocalUser,
-    moderator::{ModAddCommunity, ModAddCommunityForm},
+    moderator::{ModAddCommunity, ModAddCommunityForm, ModFeaturePost, ModFeaturePostForm},
     post::{Post, PostUpdateForm},
   },
   traits::{Crud, Joinable},
@@ -128,9 +128,10 @@ impl ActivityHandler for CollectionRemove {
       Community::get_by_collection_url(&mut context.pool(), &self.target.into())
         .await?
         .ok_or(LemmyErrorType::CouldntFindCommunity)?;
+    let actor = self.actor.dereference(context).await?;
+
     match collection_type {
       CollectionType::Moderators => {
-        let actor = self.actor.dereference(context).await?;
         let remove_mod = ObjectId::<ApubPerson>::from(self.object)
           .dereference(context)
           .await?;
@@ -170,11 +171,21 @@ impl ActivityHandler for CollectionRemove {
         let post = ObjectId::<ApubPost>::from(self.object)
           .dereference(context)
           .await?;
+        if post.community_id != community.id {
+          return Err(LemmyErrorType::InvalidCommunity.into());
+        }
         let form = PostUpdateForm {
           featured_community: Some(false),
           ..Default::default()
         };
         Post::update(&mut context.pool(), post.id, &form).await?;
+        let form = ModFeaturePostForm {
+          mod_person_id: actor.id,
+          post_id: post.id,
+          featured: false,
+          is_featured_community: true,
+        };
+        ModFeaturePost::create(&mut context.pool(), &form).await?;
       }
     }
     Ok(())

--- a/crates/db_schema/src/newtypes.rs
+++ b/crates/db_schema/src/newtypes.rs
@@ -71,7 +71,7 @@ pub struct LocalUserId(pub i32);
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The private message id.
-pub struct PrivateMessageId(i32);
+pub struct PrivateMessageId(pub i32);
 
 impl fmt::Display for PrivateMessageId {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -83,25 +83,25 @@ impl fmt::Display for PrivateMessageId {
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The person mention id.
-pub struct PersonMentionId(i32);
+pub struct PersonMentionId(pub i32);
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The comment report id.
-pub struct CommentReportId(i32);
+pub struct CommentReportId(pub i32);
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The post report id.
-pub struct PostReportId(i32);
+pub struct PostReportId(pub i32);
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The private message report id.
-pub struct PrivateMessageReportId(i32);
+pub struct PrivateMessageReportId(pub i32);
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
@@ -119,7 +119,7 @@ pub struct LanguageId(pub i32);
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The comment reply id.
-pub struct CommentReplyId(i32);
+pub struct CommentReplyId(pub i32);
 
 #[derive(
   Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default, Ord, PartialOrd,
@@ -140,19 +140,19 @@ pub struct ActivityId(pub i64);
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The local site id.
-pub struct LocalSiteId(i32);
+pub struct LocalSiteId(pub i32);
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The custom emoji id.
-pub struct CustomEmojiId(i32);
+pub struct CustomEmojiId(pub i32);
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "full", derive(DieselNewType, TS))]
 #[cfg_attr(feature = "full", ts(export))]
 /// The registration application id.
-pub struct RegistrationApplicationId(i32);
+pub struct RegistrationApplicationId(pub i32);
 
 #[cfg(feature = "full")]
 #[derive(Serialize, Deserialize)]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   lemmy:
     # use "image" to pull down an already compiled lemmy. make sure to comment out "build".
-    # image: dessalines/lemmy:0.19.18
+    # image: dessalines/lemmy:0.19.19
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy server image for development. make sure to comment out "image".
     # run: docker compose up --build
@@ -53,7 +53,7 @@ services:
 
   lemmy-ui:
     # use "image" to pull down an already compiled lemmy-ui. make sure to comment out "build".
-    image: dessalines/lemmy-ui:0.19.18
+    image: dessalines/lemmy-ui:0.19.19
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy ui image for development. make sure to comment out "image".
     # run: docker compose up --build

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 x-ui-default: &ui-default
   init: true
-  image: dessalines/lemmy-ui:0.19.18
+  image: dessalines/lemmy-ui:0.19.19
   # assuming lemmy-ui is cloned besides lemmy directory
   # build:
   #   context: ../../../lemmy-ui

--- a/docker/federation/nginx.conf
+++ b/docker/federation/nginx.conf
@@ -33,9 +33,7 @@ http {
             }
             proxy_pass $proxpass;
 
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
 
             # Cuts off the trailing slash on URLs to make them valid
             rewrite ^(.+)/+$ $1 permanent;
@@ -72,9 +70,7 @@ http {
             }
             proxy_pass $proxpass;
 
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
 
             # Cuts off the trailing slash on URLs to make them valid
             rewrite ^(.+)/+$ $1 permanent;
@@ -111,9 +107,7 @@ http {
             }
             proxy_pass $proxpass;
 
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
 
             # Cuts off the trailing slash on URLs to make them valid
             rewrite ^(.+)/+$ $1 permanent;
@@ -150,9 +144,7 @@ http {
             }
             proxy_pass $proxpass;
 
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
 
             # Cuts off the trailing slash on URLs to make them valid
             rewrite ^(.+)/+$ $1 permanent;
@@ -189,9 +181,7 @@ http {
             }
             proxy_pass $proxpass;
 
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
 
             # Cuts off the trailing slash on URLs to make them valid
             rewrite ^(.+)/+$ $1 permanent;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -50,9 +50,7 @@ http {
 
             rewrite ^(.+)/+$ $1 permanent;
             # Send actual client IP upstream
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
         }
 
         # backend
@@ -64,9 +62,7 @@ http {
             proxy_set_header Connection "upgrade";
 
             # Send actual client IP upstream
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
         }
     }
 }


### PR DESCRIPTION
Merges upstream Lemmy release **0.19.19** into the theatl-social fork.

## Summary
- Merged upstream tag `0.19.19` into `merge/0.19.19` (clean merge, no conflicts — `ort` strategy).
- Upstream changes: login/token handling (`local_user/login.rs`), federation collection activities (`collection_add`/`collection_remove`), nginx config (`$remote_addr`), dependency bumps.

## Fork customizations verified intact
- `privileged_register` / `check_email` private API routes
- `private_api_secret` setting in `crates/utils/src/settings/structs.rs`
- `subtle` crate (constant-time compare) in `crates/api/Cargo.toml` + `Cargo.lock`
- `generate_translations.js`
- `forked-main` CI base + `merge/*` triggers in `.github/workflows/`

## Verification
Local build skipped — relying on CI (runs automatically on `merge/*` and `forked-main`).