### PR TITLE
Merge upstream 0.19.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3481,7 +3481,6 @@ dependencies = [
  "lemmy_federate",
  "lemmy_routes",
  "lemmy_utils",
- "mimalloc",
  "opentelemetry 0.21.0",
  "opentelemetry-otlp 0.14.0",
  "opentelemetry_sdk 0.21.2",
@@ -3494,6 +3493,7 @@ dependencies = [
  "rustls 0.23.27",
  "serde_json",
  "serial_test",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-actix-web",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -3591,16 +3591,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libmimalloc-sys"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -3923,15 +3913,6 @@ dependencies = [
  "migrations_internals",
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6498,6 +6479,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lemmy_api"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_common"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_api_crud"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "accept-language",
  "activitypub_federation",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_apub"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_perf"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "anyhow",
  "clap",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_schema"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "activitypub_federation",
  "anyhow",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "actix-web",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_actor"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "chrono",
  "diesel",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_db_views_moderator"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "diesel",
  "diesel-async",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_federate"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_routes"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "activitypub_federation",
  "actix-web",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_server"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "activitypub_federation",
  "actix-cors",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "lemmy_utils"
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.19"
+version = "0.19.19-jemalloc"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.19", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.19", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.19", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.19", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.19", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.19", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.19", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.19", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.19", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.19", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.19", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.19-jemalloc", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.19-jemalloc", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.19-jemalloc", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.19-jemalloc", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.19-jemalloc", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.19-jemalloc", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.19-jemalloc", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.19-jemalloc", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.19-jemalloc", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.19-jemalloc", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.19-jemalloc", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }
@@ -220,7 +220,7 @@ clap = { workspace = true }
 actix-web-prom = "0.10.0"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-mimalloc = "0.1.46"
+tikv-jemallocator = "0.7.0"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.19.19-jemalloc"
+version = "0.19.20"
 edition = "2021"
 description = "A link aggregator for the fediverse"
 license = "AGPL-3.0"
@@ -92,17 +92,17 @@ unwrap_used = "deny"
 unimplemented = "deny"
 
 [workspace.dependencies]
-lemmy_api = { version = "=0.19.19-jemalloc", path = "./crates/api" }
-lemmy_api_crud = { version = "=0.19.19-jemalloc", path = "./crates/api_crud" }
-lemmy_apub = { version = "=0.19.19-jemalloc", path = "./crates/apub" }
-lemmy_utils = { version = "=0.19.19-jemalloc", path = "./crates/utils", default-features = false }
-lemmy_db_schema = { version = "=0.19.19-jemalloc", path = "./crates/db_schema" }
-lemmy_api_common = { version = "=0.19.19-jemalloc", path = "./crates/api_common" }
-lemmy_routes = { version = "=0.19.19-jemalloc", path = "./crates/routes" }
-lemmy_db_views = { version = "=0.19.19-jemalloc", path = "./crates/db_views" }
-lemmy_db_views_actor = { version = "=0.19.19-jemalloc", path = "./crates/db_views_actor" }
-lemmy_db_views_moderator = { version = "=0.19.19-jemalloc", path = "./crates/db_views_moderator" }
-lemmy_federate = { version = "=0.19.19-jemalloc", path = "./crates/federate" }
+lemmy_api = { version = "=0.19.20", path = "./crates/api" }
+lemmy_api_crud = { version = "=0.19.20", path = "./crates/api_crud" }
+lemmy_apub = { version = "=0.19.20", path = "./crates/apub" }
+lemmy_utils = { version = "=0.19.20", path = "./crates/utils", default-features = false }
+lemmy_db_schema = { version = "=0.19.20", path = "./crates/db_schema" }
+lemmy_api_common = { version = "=0.19.20", path = "./crates/api_common" }
+lemmy_routes = { version = "=0.19.20", path = "./crates/routes" }
+lemmy_db_views = { version = "=0.19.20", path = "./crates/db_views" }
+lemmy_db_views_actor = { version = "=0.19.20", path = "./crates/db_views_actor" }
+lemmy_db_views_moderator = { version = "=0.19.20", path = "./crates/db_views_moderator" }
+lemmy_federate = { version = "=0.19.20", path = "./crates/federate" }
 activitypub_federation = { version = "0.5.11", default-features = false, features = [
   "actix-web",
 ] }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   lemmy:
     # use "image" to pull down an already compiled lemmy. make sure to comment out "build".
-    # image: dessalines/lemmy:0.19.19
+    # image: dessalines/lemmy:0.19.20
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy server image for development. make sure to comment out "image".
     # run: docker compose up --build
@@ -53,7 +53,7 @@ services:
 
   lemmy-ui:
     # use "image" to pull down an already compiled lemmy-ui. make sure to comment out "build".
-    image: dessalines/lemmy-ui:0.19.19
+    image: dessalines/lemmy-ui:0.19.20
     # platform: linux/x86_64 # no arm64 support. uncomment platform if using m1.
     # use "build" to build your local lemmy ui image for development. make sure to comment out "image".
     # run: docker compose up --build

--- a/docker/federation/docker-compose.yml
+++ b/docker/federation/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 x-ui-default: &ui-default
   init: true
-  image: dessalines/lemmy-ui:0.19.19
+  image: dessalines/lemmy-ui:0.19.20
   # assuming lemmy-ui is cloned besides lemmy directory
   # build:
   #   context: ../../../lemmy-ui

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ use tracing_subscriber::{filter::Targets, layer::SubscriberExt, Layer, Registry}
 
 #[cfg_attr(target_arch = "x86_64", global_allocator)]
 #[cfg(target_arch = "x86_64")]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 /// Timeout for HTTP requests while sending activities. A longer timeout provides better
 /// compatibility with other ActivityPub software that might allocate more time for synchronous


### PR DESCRIPTION
Merges upstream Lemmy release `0.19.20` into the theatl-social fork.

## What's in this release

Upstream 0.19.20 is a small, targeted release — two commits:

- `1521fe945` [0.19] Try using jemalloc instead of mimalloc (#6604)
- `e9d49b7b4` Version 0.19.20

The substantive change is swapping the global allocator from `mimalloc` to
`tikv-jemallocator` on x86_64, addressing RSS growth under federation load.
Everything else is version bumps.

## Changed files (5)

| File | Change |
|---|---|
| `Cargo.toml` | `mimalloc 0.1.46` → `tikv-jemallocator 0.7.0`; workspace version bumps |
| `Cargo.lock` | dependency resolution for the above |
| `src/lib.rs` | `#[global_allocator]` now `tikv_jemallocator::Jemalloc` |
| `docker/docker-compose.yml` | image tags → 0.19.20 |
| `docker/federation/docker-compose.yml` | image tag → 0.19.20 |

## Merge notes

**Zero conflicts.** The diff of this branch against `forked-main` is exactly
upstream's 5-file changeset — no fork regressions.

Fork customizations verified intact after merge:

- [x] `privileged_register` + `check_email` routes in `src/api_routes_http.rs`
- [x] `private_api_secret` in `crates/utils/src/settings/structs.rs`
- [x] `subtle = "2.6"` in `crates/api/Cargo.toml` + `crates/api_crud/Cargo.toml`
- [x] Both `ConstantTimeEq` call sites (`check_email.rs`, `user/create.rs`)
- [x] `generate_translations.js`
- [x] `forked-main` branch triggers in `.github/workflows/docker-build.yml`

## Verification

`cargo build` passes on the pinned toolchain (Rust 1.81, per
`rust-toolchain.toml`) — 0 errors, `lemmy_server` binary builds.

Note for reviewers: the allocator swap is gated on
`#[cfg(target_arch = "x86_64")]`, so it is **not** exercised by a local arm64
build, nor by `ci.yml` (which only runs `cargo check -p <crate> --lib` on
library crates and never builds the root binary). The `docker-build.yml`
`linux/amd64` build is the only path that actually compiles this change —
that's the check worth watching here.

The DB-backed test suite was not run: it requires a live PostgreSQL, and the
`test` job in `ci.yml` is currently commented out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)